### PR TITLE
Optimize release checking and prevent ordering issues

### DIFF
--- a/src/SelfUpdateCommand.php
+++ b/src/SelfUpdateCommand.php
@@ -87,7 +87,7 @@ EOT
         $releases = file_get_contents($url, false, $context);
         $releases = json_decode($releases);
 
-        if (! isset($releases[0])) {
+        if (isset($releases->message)) {
             throw new \Exception('API error - no release found at GitHub repository ' . $this->gitHubRepository);
         }
         return $releases;


### PR DESCRIPTION
This changes the stable channel to greedily check the `/latest` Github endpoint first before falling back to the full release API. This has two benefits for the vast majority of users:
- Much smaller response size from the Github API, speeding up calls
- Fixes https://github.com/consolidation/self-update/issues/9

There are two situations that do not benefit from this fix, for them everything works exactly as before (i.e. we fall back to popping the first release from the full release API)
- When a user checks for updates immediately after a new release but before the phar is built
- When a user is on the unstable/preview channel

## Test steps

Testing this is somewhat laborious, sorry. I've documented the process though: https://github.com/acquia/cli/pull/458

Start by cloning this fork of self-update locally and checking out the feature branch. Then follow those steps to link `consolidation/self-update` (this fork) into the Acquia CLI build, tweak the version string, build the phar, and finally try running the `self-update` command.

@anavarre and @grasmick can you please review